### PR TITLE
Deeplink Flow

### DIFF
--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A011ABFD25D98DF20082E0D3 /* DeeplinkFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A011ABFC25D98DF20082E0D3 /* DeeplinkFlow.swift */; };
+		A011AC0325D98EB10082E0D3 /* DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A011AC0225D98EB10082E0D3 /* DeeplinkTests.swift */; };
+		A011AC0925D99D010082E0D3 /* DeeplinkStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = A011AC0825D99D010082E0D3 /* DeeplinkStep.swift */; };
 		A026AAE525D445D600A95DCC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A026AAE425D445D600A95DCC /* Assets.xcassets */; };
 		A026AAE825D445D600A95DCC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A026AAE625D445D600A95DCC /* LaunchScreen.storyboard */; };
 		A026AAF325D445D700A95DCC /* WeatherAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A026AAF225D445D700A95DCC /* WeatherAppTests.swift */; };
@@ -39,6 +42,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A011ABFC25D98DF20082E0D3 /* DeeplinkFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkFlow.swift; sourceTree = "<group>"; };
+		A011AC0225D98EB10082E0D3 /* DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkTests.swift; sourceTree = "<group>"; };
+		A011AC0825D99D010082E0D3 /* DeeplinkStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeeplinkStep.swift; sourceTree = "<group>"; };
 		A026AAD825D445D500A95DCC /* WeatherApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeatherApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A026AAE425D445D600A95DCC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A026AAE725D445D600A95DCC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -82,6 +88,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A011ABFB25D98DE70082E0D3 /* Deeplink */ = {
+			isa = PBXGroup;
+			children = (
+				A011ABFC25D98DF20082E0D3 /* DeeplinkFlow.swift */,
+				A011AC0825D99D010082E0D3 /* DeeplinkStep.swift */,
+			);
+			path = Deeplink;
+			sourceTree = "<group>";
+		};
 		A026AACF25D445D500A95DCC = {
 			isa = PBXGroup;
 			children = (
@@ -116,6 +131,7 @@
 			children = (
 				A026AAF225D445D700A95DCC /* WeatherAppTests.swift */,
 				A026AAF425D445D700A95DCC /* Info.plist */,
+				A011AC0225D98EB10082E0D3 /* DeeplinkTests.swift */,
 			);
 			path = WeatherAppTests;
 			sourceTree = "<group>";
@@ -123,6 +139,7 @@
 		A026AB1A25D4466C00A95DCC /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A011ABFB25D98DE70082E0D3 /* Deeplink */,
 				A026AB2525D446DC00A95DCC /* Modules */,
 				A026AC1F25D4688700A95DCC /* Services */,
 				A026ABE825D44ED600A95DCC /* Utils */,
@@ -289,6 +306,8 @@
 				A026AC2225D468AC00A95DCC /* WeatherApiService.swift in Sources */,
 				A026ABE125D44ABC00A95DCC /* WeatherRepository.swift in Sources */,
 				A026ABDC25D44A6900A95DCC /* WeatherPresenter.swift in Sources */,
+				A011AC0925D99D010082E0D3 /* DeeplinkStep.swift in Sources */,
+				A011ABFD25D98DF20082E0D3 /* DeeplinkFlow.swift in Sources */,
 				A026AB1D25D4466C00A95DCC /* AppDelegate.swift in Sources */,
 				A026ABD725D44A1400A95DCC /* WeatherInteractor.swift in Sources */,
 				A026AB2B25D4475B00A95DCC /* WeatherViewController.swift in Sources */,
@@ -306,6 +325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A026AAF325D445D700A95DCC /* WeatherAppTests.swift in Sources */,
+				A011AC0325D98EB10082E0D3 /* DeeplinkTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WeatherApp/Sources/Deeplink/DeeplinkFlow.swift
+++ b/WeatherApp/Sources/Deeplink/DeeplinkFlow.swift
@@ -1,0 +1,27 @@
+//
+//  DeeplinkFlow.swift
+//  WeatherApp
+//
+//  Created by Sahey on 14.02.2021.
+//
+
+import Combine
+
+open class DeeplinkFlow<DeeplinkHandler> {
+    private let subject = PassthroughSubject<DeeplinkHandler, Never>()
+    var subscribtions = Set<AnyCancellable>()
+
+    final func onStep<NextDeeplinkHandler>(
+        _ onStep: @escaping (DeeplinkHandler) -> AnyPublisher<NextDeeplinkHandler, Never>
+    ) -> DeeplinkStep<DeeplinkHandler, NextDeeplinkHandler> {
+        DeeplinkStep(flow: self, publisher: subject.eraseToAnyPublisher())
+            .onStep { deeplink in
+                onStep(deeplink)
+            }
+    }
+
+    func subcscribe(_ deeplinkHandler: DeeplinkHandler) -> Set<AnyCancellable> {
+        subject.send(deeplinkHandler)
+        return subscribtions
+    }
+}

--- a/WeatherApp/Sources/Deeplink/DeeplinkStep.swift
+++ b/WeatherApp/Sources/Deeplink/DeeplinkStep.swift
@@ -1,0 +1,37 @@
+//
+//  DeeplinkStep.swift
+//  WeatherApp
+//
+//  Created by sahey on 14.02.2021.
+//
+
+import Combine
+
+open class DeeplinkStep<DeeplinkHandlerFlow, DeeplinkHandler> {
+    private let flow: DeeplinkFlow<DeeplinkHandlerFlow>
+    private let publisher: AnyPublisher<DeeplinkHandler, Never>
+
+    init(flow: DeeplinkFlow<DeeplinkHandlerFlow>, publisher: AnyPublisher<DeeplinkHandler, Never>) {
+        self.flow = flow
+        self.publisher = publisher
+    }
+
+    func onStep<NextDeeplinkHandler>(
+        _ onStep: @escaping (DeeplinkHandler) -> AnyPublisher<NextDeeplinkHandler, Never>
+    ) -> DeeplinkStep<DeeplinkHandlerFlow, NextDeeplinkHandler> {
+        let nextStepPublisher =
+            publisher
+                .flatMap { deeplink in
+                    onStep(deeplink)
+                }
+                .eraseToAnyPublisher()
+        return DeeplinkStep<DeeplinkHandlerFlow, NextDeeplinkHandler>(flow: flow, publisher: nextStepPublisher)
+    }
+
+    @discardableResult
+    final func commit() -> DeeplinkFlow<DeeplinkHandlerFlow> {
+        let cancelable = publisher.sink { _ in }
+        flow.subscribtions.insert(cancelable)
+        return flow
+    }
+}

--- a/WeatherAppTests/DeeplinkTests.swift
+++ b/WeatherAppTests/DeeplinkTests.swift
@@ -1,0 +1,137 @@
+//
+//  DeeplinkTests.swift
+//  WeatherAppTests
+//
+//  Created by sahey on 14.02.2021.
+//
+
+import Combine
+import CoreLocation
+@testable import WeatherApp
+import XCTest
+
+// MARK: Deeplinkable protocols
+
+protocol SearchLocationDeeplinkable: AnyObject {
+    func open(location: CLLocationCoordinate2D) -> AnyPublisher<SearchLocationDeeplinkable, Never>
+}
+
+protocol TabbarDeeplinkable: AnyObject {
+    func openCurrentLocationWeather() -> AnyPublisher<TabbarDeeplinkable, Never>
+    func openSearchLocation() -> AnyPublisher<SearchLocationDeeplinkable, Never>
+}
+
+// MARK: Abstract modules
+
+open class Module {
+    var children: [Module]
+    var onVisit: (() -> Void)?
+    init(_ children: [Module] = []) {
+        self.children = children
+    }
+
+    func findChild<Child: Module>() -> Child? {
+        children.first(where: { $0 is Child }) as? Child
+    }
+}
+
+final class Tabbar: Module, TabbarDeeplinkable {
+    func openCurrentLocationWeather() -> AnyPublisher<TabbarDeeplinkable, Never> {
+        guard let module: CurrentLocationWeather = findChild() else {
+            return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+        module.onVisit?()
+        return Just(self)
+            .eraseToAnyPublisher()
+    }
+
+    func openSearchLocation() -> AnyPublisher<SearchLocationDeeplinkable, Never> {
+        guard let module: SearchLocation = findChild() else {
+            return Empty(completeImmediately: true).eraseToAnyPublisher()
+        }
+        module.onVisit?()
+        return Just(module)
+            .eraseToAnyPublisher()
+    }
+}
+
+final class CurrentLocationWeather: Module {}
+
+final class SearchLocation: Module, SearchLocationDeeplinkable {
+    private let passthrougObject = PassthroughSubject<SearchLocationDeeplinkable, Never>()
+
+    func open(location: CLLocationCoordinate2D) -> AnyPublisher<SearchLocationDeeplinkable, Never> {
+        if let module: WeatherForCoordinate = findChild() {
+            // simluate async delay, could be network request or any other async event
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                module.receiveCoordinate = location
+                module.onVisit?()
+                self.passthrougObject.send(self)
+            }
+        }
+        return passthrougObject
+            .eraseToAnyPublisher()
+    }
+}
+
+final class WeatherForCoordinate: Module {
+    var receiveCoordinate: CLLocationCoordinate2D?
+}
+
+// MARK: Flows
+
+final class DeeplinkWeather: DeeplinkFlow<Tabbar> {
+    init(location: CLLocationCoordinate2D) {
+        super.init()
+        onStep { deeplink in
+            deeplink.openSearchLocation()
+        }
+        .onStep { deeplink in
+            deeplink.open(location: location)
+        }
+        .commit()
+    }
+}
+
+class DeeplinkTests: XCTestCase {
+    private var subject: DeeplinkWeather!
+
+    private var tabbar: Tabbar!
+    private var currentLocationWeather: CurrentLocationWeather!
+    private var searchLocation: SearchLocation!
+    private var weather: WeatherForCoordinate!
+    private var location: CLLocationCoordinate2D!
+    private var subscribtion: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        location = .random
+        weather = WeatherForCoordinate()
+        searchLocation = SearchLocation([weather])
+        currentLocationWeather = CurrentLocationWeather()
+        tabbar = Tabbar([
+            currentLocationWeather,
+            searchLocation
+        ])
+    }
+
+    func testExample() throws {
+        // given
+        let deeplinkExpectation = expectation(description: "Deeplinking to location")
+        weather.onVisit = {
+            deeplinkExpectation.fulfill()
+            XCTAssertNotNil(self.weather.receiveCoordinate, "should pass coordinate")
+        }
+        subject = DeeplinkWeather(location: location)
+        // when
+        subscribtion = subject.subcscribe(tabbar)
+        // then
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}
+
+extension CLLocationCoordinate2D {
+    static var random: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: Double.random(in: -90...90), longitude: Double.random(in: -180...180))
+    }
+}


### PR DESCRIPTION
Now App could be deep linkable!

Using the generic class `DeeplinkFlow`, you could create any concrete deep link for your scenario.
The API of the `DeeplinkFlow` is declarative which makes any deep-link flow easy to read:
``` Swift
final class DeeplinkWeatherForLocation: DeeplinkFlow<Deeplinkable> {
    init(location: CLLocationCoordinate2D) {
        super.init()
        onStep { deeplink in
            deeplink.openSearchLocation()
        }
        .onStep { deeplink in
            deeplink.open(location: location)
        }
        .commit()
    }
}
```